### PR TITLE
 Create virtual environment for python packages

### DIFF
--- a/tpcc/ydb/run_ydb.sh
+++ b/tpcc/ydb/run_ydb.sh
@@ -3,6 +3,8 @@
 export TZ=UTC
 export LC_ALL=en_US.UTF-8
 
+source ./venv/bin/activate
+
 execute_time_seconds=300
 warmup_time_seconds=60
 

--- a/tpcc/ydb/run_ydb.sh
+++ b/tpcc/ydb/run_ydb.sh
@@ -3,7 +3,7 @@
 export TZ=UTC
 export LC_ALL=en_US.UTF-8
 
-if [[ -x ./venv/bin/activate ]]; then
+if [[ -f ./venv/bin/activate ]]; then
     source ./venv/bin/activate
 else
     echo "No venv found"

--- a/tpcc/ydb/run_ydb.sh
+++ b/tpcc/ydb/run_ydb.sh
@@ -9,7 +9,6 @@ else
     echo "No venv found"
 fi
 
-
 execute_time_seconds=300
 warmup_time_seconds=60
 

--- a/tpcc/ydb/run_ydb.sh
+++ b/tpcc/ydb/run_ydb.sh
@@ -3,7 +3,12 @@
 export TZ=UTC
 export LC_ALL=en_US.UTF-8
 
-source ./venv/bin/activate
+if [[ -x ./venv/bin/activate ]]; then
+    source ./venv/bin/activate
+else
+    echo "No venv found"
+fi
+
 
 execute_time_seconds=300
 warmup_time_seconds=60

--- a/tpcc/ydb/setup_tpcc_nodes.sh
+++ b/tpcc/ydb/setup_tpcc_nodes.sh
@@ -8,14 +8,14 @@ usage() {
 unique_hosts=
 
 cleanup() {
-    if [ -n "$unique_hosts" ]; then
+    if [[ -n "$unique_hosts" ]]; then
         rm -f $unique_hosts
     fi
 }
 
 trap cleanup EXIT
 
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         --hosts)
             shift
@@ -29,13 +29,13 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [ -z "$hosts" ]; then
+if [[ -z $hosts ]]; then
     echo "Hosts file not specified"
     usage
     exit 1
 fi
 
-if [ ! -f "$hosts" ]; then
+if [[ ! -f $hosts ]]; then
     echo "Hosts file $hosts not found"
     exit 1
 fi
@@ -49,7 +49,7 @@ function setup_python {
 
     venv_dir="$script_dir/venv"
 
-    if [ ! -d $venv_dir ]; then
+    if [[ ! -d $venv_dir ]]; then
         python3 -m venv $venv_dir
         if [[ $? -ne 0 ]]; then
             echo "Faild to create virtual environment $venv_dir"
@@ -64,6 +64,8 @@ function setup_python {
         echo "Faild to activate virtual environment $venv_dir"
         return 1
     fi
+
+    echo "Virtial environment $venv_dir activated"
 
     pip3 install ydb ydb[yc] numpy requests
     if [[ $? -ne 0 ]]; then
@@ -91,6 +93,11 @@ else
 fi
 
 setup_python
+if [[ $? -ne 0 ]]; then
+    # Error message is generated in the function
+    some_failed=1
+fi
+
 
 curl -sSL https://storage.yandexcloud.net/yandexcloud-ydb/install.sh | bash
 if [[ $? -ne 0 ]]; then
@@ -110,7 +117,7 @@ if [[ $? -ne 0 ]]; then
     some_failed=1
 fi
 
-if [ -n "$some_failed" ]; then
+if [[ -n "$some_failed" ]]; then
     echo "Some steps failed. Please fix the issues manually"
     exit 1
 fi

--- a/tpcc/ydb/setup_tpcc_nodes.sh
+++ b/tpcc/ydb/setup_tpcc_nodes.sh
@@ -8,7 +8,7 @@ usage() {
 unique_hosts=
 
 cleanup() {
-    if [[ -n "$unique_hosts" ]]; then
+    if [[ -n $unique_hosts ]]; then
         rm -f $unique_hosts
     fi
 }
@@ -117,7 +117,7 @@ if [[ $? -ne 0 ]]; then
     some_failed=1
 fi
 
-if [[ -n "$some_failed" ]]; then
+if [[ -n $some_failed ]]; then
     echo "Some steps failed. Please fix the issues manually"
     exit 1
 fi

--- a/tpcc/ydb/setup_tpcc_nodes.sh
+++ b/tpcc/ydb/setup_tpcc_nodes.sh
@@ -41,14 +41,10 @@ if [ ! -f "$hosts" ]; then
 fi
 
 function setup_python {
-    if ! which pip3 >/dev/null; then
-        sudo apt-get install -yyq python3-pip
-        if [[ $? -ne 0 ]]; then
-            echo "Failed to install pip3 using apt-get. Please install it manually"
-            return 1
-        fi
-    else
-        echo "pip3 already installed"
+    sudo apt-get install -yyq python3-pip python3-venv
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to install pip3 or venv using apt-get. Please install it manually"
+        return 1
     fi
 
     venv_dir="$script_dir/venv"


### PR DESCRIPTION
It is prohibited to install python packages globally in Ubuntu. Also, it is considered bad practice to do so.
This PR adds venv creation and usage to setup_tpcc_nodes.sh and run_ydb.sh.